### PR TITLE
Config client from env

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+# build artifacts
+bin/
+obj/

--- a/MoneyTransferClient/MoneyTransferClient.csproj
+++ b/MoneyTransferClient/MoneyTransferClient.csproj
@@ -8,12 +8,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Temporalio" Version="1.0.0" />
-    <PackageReference Include="Temporalio.Extensions.Hosting" Version="1.0.0" />
+    <PackageReference Include="Temporalio" Version="1.4.0" />
+    <PackageReference Include="Temporalio.Extensions.Hosting" Version="1.4.0" />
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\MoneyTransferWorker\MoneyTransferWorker.csproj" />
   </ItemGroup>
-
 </Project>

--- a/MoneyTransferClient/Program.cs
+++ b/MoneyTransferClient/Program.cs
@@ -3,8 +3,10 @@
 using Temporalio.MoneyTransferProject.MoneyTransferWorker;
 using Temporalio.Client;
 
-// Connect to the Temporal server
-var client = await TemporalClient.ConnectAsync(new("localhost:7233") { Namespace = "default" });
+// Use a helper method to create a Temporal Client configured to use a 
+// specific endpoint address, Namespace, and authentication options for 
+// the Temporal Service based on the presence of some environment variables
+var client = await TemporalClientHelper.CreateClientAsync();
 
 // Define payment details
 var details = new PaymentDetails(
@@ -20,6 +22,7 @@ var workflowId = $"pay-invoice-{Guid.NewGuid()}";
 
 try
 {
+
     // Start the workflow
     var handle = await client.StartWorkflowAsync(
         (MoneyTransferWorkflow wf) => wf.RunAsync(details),

--- a/MoneyTransferTest/MoneyTransferTest.csproj
+++ b/MoneyTransferTest/MoneyTransferTest.csproj
@@ -12,7 +12,7 @@
     <PackageReference Include="Moq" Version="4.20.70" />
     <PackageReference Include="NUnit" Version="4.0.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
-    <PackageReference Include="Temporalio" Version="1.0.0" />
+    <PackageReference Include="Temporalio" Version="1.4.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/MoneyTransferWorker/MoneyTransferWorker.csproj
+++ b/MoneyTransferWorker/MoneyTransferWorker.csproj
@@ -8,8 +8,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Temporalio" Version="1.0.0" />
-    <PackageReference Include="Temporalio.Extensions.Hosting" Version="1.0.0" />
+    <PackageReference Include="Temporalio" Version="1.4.0" />
+    <PackageReference Include="Temporalio.Extensions.Hosting" Version="1.4.0" />
   </ItemGroup>
+
 
 </Project>

--- a/MoneyTransferWorker/Program.cs
+++ b/MoneyTransferWorker/Program.cs
@@ -4,8 +4,12 @@ using Temporalio.Client;
 using Temporalio.Worker;
 using Temporalio.MoneyTransferProject.MoneyTransferWorker;
 
-// Create a client to connect to localhost on "default" namespace
-var client = await TemporalClient.ConnectAsync(new("localhost:7233"));
+
+// Use a helper method to create a Temporal Client configured to use a 
+// specific endpoint address, Namespace, and authentication options for 
+// the Temporal Service based on the presence of some environment variables
+var client = await TemporalClientHelper.CreateClientAsync();
+
 
 // Cancellation token to shutdown worker on ctrl+c
 using var tokenSource = new CancellationTokenSource();

--- a/MoneyTransferWorker/TemporalClientHelper.cs
+++ b/MoneyTransferWorker/TemporalClientHelper.cs
@@ -1,0 +1,43 @@
+using System;
+using System.IO;
+using System.Collections.Generic;
+using Temporalio.Client;
+
+public static class TemporalClientHelper
+{
+    public static async Task<ITemporalClient> CreateClientAsync()
+    {
+        var address = Environment.GetEnvironmentVariable("TEMPORAL_ADDRESS") ?? "localhost:7233";
+        var ns = Environment.GetEnvironmentVariable("TEMPORAL_NAMESPACE") ?? "default";
+        var clientCertPath = Environment.GetEnvironmentVariable("TEMPORAL_TLS_CERT");
+        var clientKeyPath = Environment.GetEnvironmentVariable("TEMPORAL_TLS_KEY");
+        var apiKey = Environment.GetEnvironmentVariable("TEMPORAL_API_KEY");
+
+        var options = new TemporalClientConnectOptions(address)
+        {
+            Namespace = ns
+        };
+
+        if (!string.IsNullOrEmpty(clientCertPath) && !string.IsNullOrEmpty(clientKeyPath))
+        {
+            // mTLS authentication
+            options.Tls = new()
+            {
+                ClientCert = await File.ReadAllBytesAsync(clientCertPath),
+                ClientPrivateKey = await File.ReadAllBytesAsync(clientKeyPath),
+            };
+        }
+        else if (!string.IsNullOrEmpty(apiKey))
+        {
+            // API Key authentication
+            options.ApiKey = apiKey;
+            options.RpcMetadata = new Dictionary<string, string>()
+            {
+                ["temporal-namespace"] = ns
+            };
+            options.Tls = new();
+        }
+
+        return await TemporalClient.ConnectAsync(options);
+    }
+}


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

DO NOT MERGE.

I have created this draft PR to support review and sharing this code. However, I do not intend for this code to become part of the `main` branch, as it is my hope that what's on this branch will become obsolete when the SDKs support environment-based configuration.

## What was changed
I added code to configure Temporal Client options based on the presence of environment variables. I also updated the Clients created by the Worker and Starter code to use it.


## Why?
<!-- Tell your future self why have you made these changes -->
Currently, the clients used in this tutorial have no explicit configuration and rely solely on the default options. Imagine that someone new to Temporal application development signed up for Temporal Cloud on their own and now wants to run this intro-level money transfer tutorial. Getting it to work with Temporal Cloud requires making changes to the Client configuration, but this user won't know what to change. Note that this scenario I've described isn't limited to Temporal Cloud. Someone using a non-default Namespace name or a non-local Temporal Service would have the same problem.

Having the clients configure themselves based on the presence of environment variables eliminates the need to hardcode the frontend address, Namespace name, or authentication details. It helps the user understand that the application logic remains unchanged when migrating from the Temporal Service used for development on their laptop to a production Temporal Service (or vice versa). Finally, this makes it easier for users to run this example locally, on a remote self-hosted cluster, or on Temporal Cloud. Unfortunately, the SDKs do not support this yet (although it has been [discussed](https://github.com/temporalio/features/issues/441)), so this has to be done within the application itself in the interim. 

NOTE: I have updated the code but not the prose in the tutorial, pending further discussion with the Education team. I plan to make similar changes to the other money-transfer repos, but if it turns out that is not viable, then I will probably need to fork these repos and tutorials to support the onboarding path for new cloud users.

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

This does not close an issue, but enables further progress of EDU-3801. That issue would be closed only after all similar tutorials have been updated. 

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

I tested this in three scenarios:

### Local Temporal Service (started via CLI) using the `default` namespace. 
In this scenario, I set no environment variables. I ran the Worker and Starter code and the Workflow ran to completion. 


### Temporal Cloud, using mTLS 
In this scenario,  I set the four environment variables below (note that these values are similar to but not identical to the ones I actually set):

```bash
export TEMPORAL_ADDRESS='example.c9ef8.tmprl.cloud:7233'
export TEMPORAL_NAMESPACE='example.c9ef8'
export TEMPORAL_TLS_CERT='mycert.pem'
export TEMPORAL_TLS_KEY='mykey.key'
```

To verify that mTLS was used for authentication, I disabled API Keys for authentication on the Namespace in this scenario. I then ran the Worker and Starter code and the Workflow ran to completion. 

### Temporal Cloud, using API Keys 
In this scenario,  I set the three environment variables below (note that these values are similar to but not identical to the ones I actually set):

```bash
export TEMPORAL_ADDRESS='us-east-1.aws.api.temporal.io'
export TEMPORAL_NAMESPACE='example.c9ef8'
export TEMPORAL_API_KEY='abc123.actual.value.redacted.xyz789' 
```

To verify that the API keys were used for authentication, I disabled mTLS authentication on the Namespace in this scenario. I then ran the Worker and Starter code and the Workflow ran to completion. 


3. Any docs updates needed?

The tutorial prose will require a small update to describe the changes and explain which environment variables one must set for non-default scenarios.